### PR TITLE
Travis CI: Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
 language: python
 matrix:
+  allow_failures:
+  - python: '3.7'
   include:
-  - os: linux
-    dist: trusty
-    sudo: false
-    python: '2.7'
+  - python: '2.7'
+    os: linux
+  - python: '3.7'
+    os: linux
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
   - os: osx
     language: objective-c
     env: PYENV_VERSION=2.7.12
 # command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - python test/__init__.py
 deploy:


### PR DESCRIPTION
Where is __WebDialog__ defined?

[flake8](http://flake8.pycqa.org) testing of https://github.com/Tencent/QTAF on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tuia/_autoweb/__init__.py:307:20: F821 undefined name 'WebDialog'
            return WebDialog(self._obj)
                   ^
1     F821 undefined name 'WebDialog'
1
```