### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22